### PR TITLE
Fixed ExpressionType.Convert SqlVisitor issue.

### DIFF
--- a/Lambdy.Tests/Casting/CastingTest.cs
+++ b/Lambdy.Tests/Casting/CastingTest.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using FluentAssertions;
+using Lambdy.Tests.TestModels.NorthwindTables;
+using Xunit;
+
+namespace Lambdy.Tests.Casting
+{
+    public class CastingTest
+    {
+        [Fact]
+        public void WhereInputCastShouldWork()
+        {
+            var orderId = 222;
+            
+            Action act = () =>
+            {
+                LambdyQuery
+                    .ByModel(new
+                    {
+                        Table = (OrderDetail) null
+                    })
+                    .Where(x => x.Table.OrderId == orderId)
+                    .Compile();
+            };
+            
+            act
+                .Should()
+                .NotThrow<Exception>();
+        }
+    }
+}

--- a/Lambdy/Visitors/ExpressionNodeSql/ExpressionNodeSqlVisitor.cs
+++ b/Lambdy/Visitors/ExpressionNodeSql/ExpressionNodeSqlVisitor.cs
@@ -24,7 +24,8 @@ namespace Lambdy.Visitors.ExpressionNodeSql
                 {ExpressionType.LessThanOrEqual, SqlComparisionOperators.LessThanOrEqual},
                 {ExpressionType.AndAlso, SqlBooleanLogicalOperators.And},
                 {ExpressionType.OrElse, SqlBooleanLogicalOperators.Or},
-                {ExpressionType.Not, SqlBooleanLogicalOperators.Not}
+                {ExpressionType.Not, SqlBooleanLogicalOperators.Not},
+                {ExpressionType.Convert, string.Empty} //We do not do conversion operations, just pass value!
             };
         
         private static readonly IReadOnlyDictionary<LikeMethod, string> LikeDictionary =


### PR DESCRIPTION
- The values of ExpressionType.Convert are already converted on .NET when parsing expression tree, we don't need to pass conversion operations to SQL