### PR TITLE
Lambdy builder as interface with extensions

### DIFF
--- a/Lambdy.Tests/Alias/AliasTest.cs
+++ b/Lambdy.Tests/Alias/AliasTest.cs
@@ -18,7 +18,7 @@ namespace Lambdy.Tests.Alias
                 {
                     TableOne = (Person) null,
                     T = (Address) null,
-                    Table3 = (TableC) null,
+                    Table3 = (Customer) null,
                 })
                 .Where(x => x.T.Id == Guid.Empty)
                 .Compile();

--- a/Lambdy.Tests/Casting/CastingTest.cs
+++ b/Lambdy.Tests/Casting/CastingTest.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using FluentAssertions;
+using Lambdy.Tests.Casting.Extensions;
+using Lambdy.Tests.Casting.Models;
 using Lambdy.Tests.TestModels.NorthwindTables;
 using Xunit;
 
@@ -26,6 +28,39 @@ namespace Lambdy.Tests.Casting
             act
                 .Should()
                 .NotThrow<Exception>();
+        }
+        
+        [Fact]
+        public void AllowChildToCallParentExtensions()
+        {
+            var expectedResult = "PersonAlias.Id = ";
+
+            var sqlResult = LambdyQuery
+                .ByModel<TreeTableJoin>()
+                .FilterTwoTable()
+                .Compile();
+
+            sqlResult
+                .Sql
+                .Should()
+                .Contain(expectedResult);
+        }
+        
+        [Fact]
+        public void CastBackToDerivedShouldWork()
+        {
+            var expectedResult = "PersonAlias.Id = ";
+
+            var sqlResult = LambdyQuery
+                .ByModel<TreeTableJoin>()
+                .FilterTwoTable()
+                .Cast<TreeTableJoin>()
+                .Compile();
+
+            sqlResult
+                .Sql
+                .Should()
+                .Contain(expectedResult);
         }
     }
 }

--- a/Lambdy.Tests/Casting/Extensions/TwoTableBuilderExtensions.cs
+++ b/Lambdy.Tests/Casting/Extensions/TwoTableBuilderExtensions.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using Lambdy.Tests.Casting.Models;
+using Lambdy;
+
+namespace Lambdy.Tests.Casting.Extensions
+{
+    public static class TwoTableBuilderExtensions
+    {
+        public static ILambdyBuilder<TwoTableJoin> FilterTwoTable(
+            this ILambdyBuilder<TwoTableJoin> builder)
+        {
+            builder.Where(x => x.PersonAlias.Id == Guid.Empty);
+            return builder;
+        }
+    }
+}

--- a/Lambdy.Tests/Casting/Models/TreeTableJoin.cs
+++ b/Lambdy.Tests/Casting/Models/TreeTableJoin.cs
@@ -1,0 +1,9 @@
+﻿using Lambdy.Tests.TestModels.NorthwindTables;
+
+namespace Lambdy.Tests.Casting.Models
+{
+    public class TreeTableJoin : TwoTableJoin
+    {
+        public Customer Customer { get; set; }
+    }
+}

--- a/Lambdy.Tests/Casting/Models/TwoTableJoin.cs
+++ b/Lambdy.Tests/Casting/Models/TwoTableJoin.cs
@@ -1,13 +1,11 @@
 ﻿using Lambdy.Tests.TestModels.Tables;
 
-namespace Lambdy.Tests.Alias.Models
+namespace Lambdy.Tests.Casting.Models
 {
-    public class SimpleSelectAlias
+    public class TwoTableJoin
     {
         public Person PersonAlias { get; set; }
         
         public Address AddressAlias { get; set; }
-        
-        public Customer Customer { get; set; }
     }
 }

--- a/Lambdy.Tests/OrderBy/OrderByTest.cs
+++ b/Lambdy.Tests/OrderBy/OrderByTest.cs
@@ -17,7 +17,7 @@ namespace Lambdy.Tests.OrderBy
                 {
                     TableOne = (Person) null,
                     T = (Address) null,
-                    Table3 = (TableC) null,
+                    Table3 = (Customer) null,
                 })
                 .OrderBy(x => x.TableOne.Id)
                 .Compile();
@@ -39,7 +39,7 @@ namespace Lambdy.Tests.OrderBy
                 {
                     TableOne = (Person) null,
                     T = (Address) null,
-                    Table3 = (TableC) null,
+                    Table3 = (Customer) null,
                 })
                 .OrderBy(x => x.TableOne.Id)
                 .ThenBy(x => x.T.AddressLine2)
@@ -61,7 +61,7 @@ namespace Lambdy.Tests.OrderBy
                 {
                     TableOne = (Person) null,
                     T = (Address) null,
-                    Table3 = (TableC) null,
+                    Table3 = (Customer) null,
                 })
                 .OrderByDescending(x => x.TableOne.Id)
                 .Compile();
@@ -83,7 +83,7 @@ namespace Lambdy.Tests.OrderBy
                 {
                     TableOne = (Person) null,
                     T = (Address) null,
-                    Table3 = (TableC) null,
+                    Table3 = (Customer) null,
                 })
                 .OrderByDescending(x => x.TableOne.Id)
                 .ThenByDescending(x => x.T.AddressLine2)
@@ -108,7 +108,7 @@ namespace Lambdy.Tests.OrderBy
                 {
                     TableOne = (Person) null,
                     T = (Address) null,
-                    Table3 = (TableC) null,
+                    Table3 = (Customer) null,
                 })
                 .OrderBy(x => x.TableOne.Id)
                 .ThenByDescending(x => x.T.AddressLine2)

--- a/Lambdy.Tests/SkipTake/MsSqlSkipTakeTest.cs
+++ b/Lambdy.Tests/SkipTake/MsSqlSkipTakeTest.cs
@@ -15,7 +15,7 @@ namespace Lambdy.Tests.SkipTake
                 {
                     TableOne = (Person) null,
                     T = (Address) null,
-                    Table3 = (TableC) null,
+                    Table3 = (Customer) null,
                 })
                 .Skip(10)
                 .Take(50)

--- a/Lambdy.Tests/SkipTake/SqlLiteSkipTakeTest.cs
+++ b/Lambdy.Tests/SkipTake/SqlLiteSkipTakeTest.cs
@@ -16,7 +16,7 @@ namespace Lambdy.Tests.SkipTake
                 {
                     TableOne = (Person) null,
                     T = (Address) null,
-                    Table3 = (TableC) null,
+                    Table3 = (Customer) null,
                 })
                 .Skip(10)
                 .Take(50)

--- a/Lambdy.Tests/TestModels/Tables/Customer.cs
+++ b/Lambdy.Tests/TestModels/Tables/Customer.cs
@@ -2,7 +2,7 @@
 
 namespace Lambdy.Tests.TestModels.Tables
 {
-    public class TableC
+    public class Customer
     {
         public Guid Id { get; set; }
         

--- a/Lambdy/Builders/SubBuilders/Expressions/ExpressionBuilder.cs
+++ b/Lambdy/Builders/SubBuilders/Expressions/ExpressionBuilder.cs
@@ -1,0 +1,73 @@
+﻿using System.Collections.Generic;
+using Lambdy.Builders.SubBuilders.Expressions.Interfaces;
+using Lambdy.Resolvers;
+using Lambdy.TreeNodes.ClauseSectionNodes;
+using Lambdy.ValueObjects;
+
+namespace Lambdy.Builders.SubBuilders.Expressions
+{
+    internal class ExpressionBuilder : IExpressionBuilder 
+    {
+        private readonly ExpressionBuilderClauseReferences _clauseReferences;
+        
+        public ExpressionBuilder(
+            ExpressionBuilderClauseReferences clauseReferences)
+        {
+            _clauseReferences = clauseReferences;
+        }
+        
+        public void AddSelectExpression(System.Linq.Expressions.Expression exprBody)
+        {
+            _clauseReferences.SelectClause.Node = ExpressionResolverMediator
+                .ResolveExpression(exprBody);
+        }
+        
+        public void AddWhereExpression(System.Linq.Expressions.Expression exprBody)
+        {
+            _clauseReferences.WhereClause.Nodes
+                .Add(ExpressionResolverMediator.ResolveExpression(exprBody));
+        }
+
+        public void AddOrderByExpression(System.Linq.Expressions.Expression exprBody)
+        {
+            _clauseReferences.OrderClause.Nodes = new List<OrderClauseEntryNode>()
+            {
+                new OrderClauseEntryNode()
+                {
+                    Node = ExpressionResolverMediator.ResolveExpression(exprBody),
+                    Direction = OrderDirection.Asc
+                }
+            };
+        }
+        
+        public void AddThenByExpression(System.Linq.Expressions.Expression exprBody)
+        {
+            _clauseReferences.OrderClause.Nodes.Add(new OrderClauseEntryNode()
+            {
+                Direction = OrderDirection.Asc,
+                Node = ExpressionResolverMediator.ResolveExpression(exprBody)
+            });
+        }
+        
+        public void AddOrderByDescExpression(System.Linq.Expressions.Expression exprBody)
+        {
+            _clauseReferences.OrderClause.Nodes = new List<OrderClauseEntryNode>()
+            {
+                new OrderClauseEntryNode()
+                {
+                    Node = ExpressionResolverMediator.ResolveExpression(exprBody),
+                    Direction = OrderDirection.Desc
+                }
+            };
+        }
+        
+        public void AddThenByDescExpression(System.Linq.Expressions.Expression exprBody)
+        {
+            _clauseReferences.OrderClause.Nodes.Add(new OrderClauseEntryNode()
+            {
+                Direction = OrderDirection.Desc,
+                Node = ExpressionResolverMediator.ResolveExpression(exprBody)
+            });
+        }
+    }
+}

--- a/Lambdy/Builders/SubBuilders/Expressions/ExpressionBuilderClauseReferences.cs
+++ b/Lambdy/Builders/SubBuilders/Expressions/ExpressionBuilderClauseReferences.cs
@@ -1,9 +1,8 @@
 ﻿using Lambdy.TreeNodes.ClauseSectionNodes;
-// ReSharper disable UnusedAutoPropertyAccessor.Global
 
-namespace Lambdy.SubBuilders.Raw
+namespace Lambdy.Builders.SubBuilders.Expressions
 {
-    internal class RawBuilderClauseReferences
+    internal class ExpressionBuilderClauseReferences
     {
         public SelectClauseNode SelectClause { get; set; }
         public FromClauseNode FromClause { get; set; }

--- a/Lambdy/Builders/SubBuilders/Expressions/Interfaces/IExpressionBuilder.cs
+++ b/Lambdy/Builders/SubBuilders/Expressions/Interfaces/IExpressionBuilder.cs
@@ -1,0 +1,17 @@
+﻿namespace Lambdy.Builders.SubBuilders.Expressions.Interfaces
+{
+    public interface IExpressionBuilder
+    {
+        void AddSelectExpression(System.Linq.Expressions.Expression exprBody);
+
+        void AddWhereExpression(System.Linq.Expressions.Expression exprBody);
+
+        void AddOrderByExpression(System.Linq.Expressions.Expression exprBody);
+
+        void AddThenByExpression(System.Linq.Expressions.Expression exprBody);
+
+        void AddOrderByDescExpression(System.Linq.Expressions.Expression exprBody);
+
+        void AddThenByDescExpression(System.Linq.Expressions.Expression exprBody);
+    }
+}

--- a/Lambdy/Builders/SubBuilders/Raw/Interfaces/IRawBuilder.cs
+++ b/Lambdy/Builders/SubBuilders/Raw/Interfaces/IRawBuilder.cs
@@ -1,0 +1,26 @@
+﻿namespace Lambdy.Builders.SubBuilders.Raw.Interfaces
+{
+    public interface IRawBuilder<out TModel> 
+        where TModel: class
+    {
+        ILambdyBuilder<TModel> From(
+            string sqlFragment);
+
+        ILambdyBuilder<TModel> Join(
+            string sqlFragment);
+
+        ILambdyBuilder<TModel> Where(
+            string sqlFragment);
+
+        ILambdyBuilder<TModel> Where(
+            string sqlFragment,
+            object parameters);
+
+        ILambdyBuilder<TModel> OrderBy(
+            string sqlFragment);
+
+        ILambdyBuilder<TModel> OrderBy(
+            string sqlFragment,
+            object parameters);
+    }
+}

--- a/Lambdy/Builders/SubBuilders/Raw/RawBuilder.cs
+++ b/Lambdy/Builders/SubBuilders/Raw/RawBuilder.cs
@@ -1,21 +1,23 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using Lambdy.Builders.SubBuilders.Raw.Interfaces;
 using Lambdy.Constants.Sql;
 using Lambdy.Parameters;
 using Lambdy.TreeNodes.ClauseSectionNodes;
 using Lambdy.TreeNodes.ExpressionNodes;
 
-namespace Lambdy.SubBuilders.Raw
+namespace Lambdy.Builders.SubBuilders.Raw
 {
-    public class RawBuilder<TModel> where TModel: class
+    public class RawBuilder<TModel> : IRawBuilder<TModel>
+        where TModel: class
     {
-        private readonly LambdyBuilder<TModel> _parentBuilder;
+        private readonly ILambdyBuilder<TModel> _parentBuilder;
         private readonly ParameterTracker _parentParameterTracker;
         private readonly RawBuilderClauseReferences _clauseReferences;
         
         internal RawBuilder(
-            LambdyBuilder<TModel> parentBuilder,
+            ILambdyBuilder<TModel> parentBuilder,
             ParameterTracker parameterTracker,
             RawBuilderClauseReferences references)
         {
@@ -24,7 +26,7 @@ namespace Lambdy.SubBuilders.Raw
             _clauseReferences = references;
         }
 
-        public LambdyBuilder<TModel> From(string sqlFragment)
+        public ILambdyBuilder<TModel> From(string sqlFragment)
         {
             sqlFragment = SubstringSqlClause(sqlFragment, SqlClauses.From);
             
@@ -35,7 +37,7 @@ namespace Lambdy.SubBuilders.Raw
             return _parentBuilder;
         }
         
-        public LambdyBuilder<TModel> Join(string sqlFragment)
+        public ILambdyBuilder<TModel> Join(string sqlFragment)
         {
             _clauseReferences
                 .JoinClause
@@ -45,7 +47,7 @@ namespace Lambdy.SubBuilders.Raw
             return _parentBuilder;
         }
         
-        public LambdyBuilder<TModel> Where(
+        public ILambdyBuilder<TModel> Where(
             string sqlFragment)
         {
             sqlFragment = SubstringSqlClause(sqlFragment, SqlClauses.Where);
@@ -58,7 +60,7 @@ namespace Lambdy.SubBuilders.Raw
             return _parentBuilder;
         }
         
-        public LambdyBuilder<TModel> Where(
+        public ILambdyBuilder<TModel> Where(
             string sqlFragment,
             object parameters)
         {
@@ -68,7 +70,7 @@ namespace Lambdy.SubBuilders.Raw
             return _parentBuilder;
         }
         
-        public LambdyBuilder<TModel> OrderBy(
+        public ILambdyBuilder<TModel> OrderBy(
             string sqlFragment)
         {
             sqlFragment = SubstringSqlClause(sqlFragment, SqlClauses.OrderBy);
@@ -86,7 +88,7 @@ namespace Lambdy.SubBuilders.Raw
             return _parentBuilder;
         }
         
-        public LambdyBuilder<TModel> OrderBy(
+        public ILambdyBuilder<TModel> OrderBy(
             string sqlFragment,
             object parameters)
         {

--- a/Lambdy/Builders/SubBuilders/Raw/RawBuilderClauseReferences.cs
+++ b/Lambdy/Builders/SubBuilders/Raw/RawBuilderClauseReferences.cs
@@ -1,0 +1,16 @@
+﻿using Lambdy.TreeNodes.ClauseSectionNodes;
+
+// ReSharper disable UnusedAutoPropertyAccessor.Global
+
+namespace Lambdy.Builders.SubBuilders.Raw
+{
+    internal class RawBuilderClauseReferences
+    {
+        public SelectClauseNode SelectClause { get; set; }
+        public FromClauseNode FromClause { get; set; }
+        public JoinClauseNode JoinClause { get; set; }
+        public WhereClauseNode WhereClause { get; set; }
+        public OrderClauseNode OrderClause { get; set; }
+        public SkipTakeClauseNode SkipTakeClause  { get; set; }
+    }
+}

--- a/Lambdy/ILambdyBuilder.cs
+++ b/Lambdy/ILambdyBuilder.cs
@@ -1,0 +1,18 @@
+﻿using Lambdy.Builders.SubBuilders.Raw.Interfaces;
+
+namespace Lambdy
+{
+    public interface ILambdyBuilder<out TModel> : ILambdyBuilderCore
+        where TModel: class
+    {
+        IRawBuilder<TModel> Raw { get; }
+
+        ILambdyBuilder<TModel> WithTemplate(string sqlTemplate);
+
+        ILambdyBuilder<TModel> InDialect(LambdySqlDialect dialect);
+        
+        ILambdyBuilder<TModel> Skip(int amount);
+
+        ILambdyBuilder<TModel> Take(int amount);
+    }
+}

--- a/Lambdy/ILambdyBuilderCore.cs
+++ b/Lambdy/ILambdyBuilderCore.cs
@@ -1,0 +1,13 @@
+﻿using Lambdy.Builders.SubBuilders.Expressions.Interfaces;
+
+namespace Lambdy
+{
+    public interface ILambdyBuilderCore
+    {
+        IExpressionBuilder ExpressionBuilder { get; }
+
+        LambdyResult Compile();
+
+        LambdyResult Compile(LambdyCompilerOptions options);
+    }
+}

--- a/Lambdy/LambdyBuilderCoreExtensions.cs
+++ b/Lambdy/LambdyBuilderCoreExtensions.cs
@@ -1,0 +1,12 @@
+﻿namespace Lambdy
+{
+    public static class LambdyBuilderCoreExtensions
+    {
+        public static ILambdyBuilder<TTarget> Cast<TTarget>(
+            this ILambdyBuilderCore lambdyBuilder)
+            where TTarget : class
+        {
+            return (ILambdyBuilder<TTarget>) lambdyBuilder;
+        }
+    }
+}

--- a/Lambdy/LambdyBuilderExtensions.cs
+++ b/Lambdy/LambdyBuilderExtensions.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Linq.Expressions;
+
+namespace Lambdy
+{
+    public static class LambdyBuilderExtensions
+    {
+        public static ILambdyBuilder<TModel> Select<TModel, TSelectModel>(
+            this ILambdyBuilder<TModel> lambdyBuilder,
+            Expression<Func<TModel, TSelectModel>> expression)
+            where TModel: class
+        {
+            lambdyBuilder
+                .ExpressionBuilder
+                .AddSelectExpression(expression.Body);
+            return lambdyBuilder;
+        }
+        
+        public static ILambdyBuilder<TModel> Where<TModel>(
+            this ILambdyBuilder<TModel> lambdyBuilder,
+            Expression<Func<TModel, bool>> expression) 
+            where TModel: class
+        {
+            lambdyBuilder
+                .ExpressionBuilder
+                .AddWhereExpression(expression.Body);
+            return lambdyBuilder;
+        }
+
+        public static ILambdyBuilder<TModel> OrderBy<TModel, TKey>(
+            this ILambdyBuilder<TModel> lambdyBuilder,
+            Expression<Func<TModel, TKey>> expression)
+            where TModel : class
+        {
+            lambdyBuilder
+                .ExpressionBuilder
+                .AddOrderByExpression(expression.Body);
+            return lambdyBuilder;
+        }
+
+        public static ILambdyBuilder<TModel> ThenBy<TModel, TKey>(
+            this ILambdyBuilder<TModel> lambdyBuilder,
+            Expression<Func<TModel, TKey>> expression)
+            where TModel : class
+        {
+            lambdyBuilder
+                .ExpressionBuilder
+                .AddThenByExpression(expression.Body);
+            return lambdyBuilder;
+        }
+
+        public static ILambdyBuilder<TModel> OrderByDescending<TModel, TKey>(
+            this ILambdyBuilder<TModel> lambdyBuilder,
+            Expression<Func<TModel, TKey>> expression)
+            where TModel : class
+        {
+            lambdyBuilder
+                .ExpressionBuilder
+                .AddOrderByDescExpression(expression.Body);
+            return lambdyBuilder;
+        }
+
+        public static ILambdyBuilder<TModel> ThenByDescending<TModel, TKey>(
+            this ILambdyBuilder<TModel> lambdyBuilder,
+            Expression<Func<TModel, TKey>> expression)
+            where TModel : class
+        {
+            lambdyBuilder
+                .ExpressionBuilder
+                .AddThenByDescExpression(expression.Body);
+            return lambdyBuilder;
+        }
+
+
+    }
+}

--- a/Lambdy/LambdyQuery.cs
+++ b/Lambdy/LambdyQuery.cs
@@ -1,4 +1,5 @@
-﻿using Lambdy.Compilers.Query;
+﻿using Lambdy.Builders;
+using Lambdy.Compilers.Query;
 using Lambdy.Compilers.Query.Abstract;
 
 namespace Lambdy
@@ -7,12 +8,12 @@ namespace Lambdy
     {
         private static readonly QueryCompiler QueryCompiler = new RecursiveQueryCompiler();
         
-        public static LambdyBuilder<TModel> ByModel<TModel>(TModel model) where TModel: class
+        public static ILambdyBuilder<TModel> ByModel<TModel>(TModel model) where TModel: class
         {
             return ByModel<TModel>();
         }
         
-        public static LambdyBuilder<TModel> ByModel<TModel>() where TModel: class
+        public static ILambdyBuilder<TModel> ByModel<TModel>() where TModel: class
         {
             return new LambdyBuilder<TModel>(QueryCompiler);
         }


### PR DESCRIPTION
- Changed  lambdy builder to interface (needed for covariance when writing extension methods - call extension method from more derived type)
- Moved main expression building methods to extensions (otherwise the interface could not be covariant, because TModel was also as input in methods)
- Introduced cast helper method to cast back to derived type after using base extension methods