### PR TITLE
Upgrade to .NET Standard 2.1

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -10,13 +10,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 8.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -10,13 +10,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 8.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -9,13 +9,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone Repository (Latest)
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Setup .NET
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 5.0.x
+          dotnet-version: 8.0.x
       - name: Pack
         run: dotnet pack --configuration Release
       - name: NuGet push

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning">
-      <Version>3.3.37</Version>
+      <Version>3.6.113</Version>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/Lambdy.Performance.Benchmarks/Lambdy.Performance.Benchmarks.csproj
+++ b/Lambdy.Performance.Benchmarks/Lambdy.Performance.Benchmarks.csproj
@@ -2,19 +2,19 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
-      <PackageReference Include="Dapper" Version="2.0.78" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.3">
+      <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
+      <PackageReference Include="Dapper" Version="2.1.35" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
-      <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.3" />
-      <PackageReference Include="System.Data.SQLite" Version="1.0.113.7" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.0" />
+      <PackageReference Include="System.Data.SQLite" Version="1.0.118" />
     </ItemGroup>
 
     <ItemGroup>
@@ -31,8 +31,8 @@
       </None>
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
-      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.3" />
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
     </ItemGroup>
     
 

--- a/Lambdy.Tests/Lambdy.Tests.csproj
+++ b/Lambdy.Tests/Lambdy.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/Lambdy/ArgumentNullExtensions.cs
+++ b/Lambdy/ArgumentNullExtensions.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace Lambdy
+{
+    internal static class ArgumentNullExtensions
+    {
+        public static T ThrowIfNull<T>(this T argument, string paramName)
+        {
+            if (argument is null) throw new ArgumentNullException(paramName);
+            return argument;
+        }
+    }
+}

--- a/Lambdy/Builders/LambdyBuilder.cs
+++ b/Lambdy/Builders/LambdyBuilder.cs
@@ -36,7 +36,7 @@ namespace Lambdy.Builders
 
         internal LambdyBuilder(QueryCompiler queryCompiler)
         {
-            _queryCompiler = queryCompiler ?? throw new ArgumentNullException(nameof(queryCompiler));
+            _queryCompiler = queryCompiler.ThrowIfNull(nameof(queryCompiler));
             _clauseSectionNodes[0] = _selectClause;
             _clauseSectionNodes[1] = _fromClause;
             _clauseSectionNodes[2] = _joinClause;

--- a/Lambdy/Builders/LambdyBuilder.cs
+++ b/Lambdy/Builders/LambdyBuilder.cs
@@ -11,9 +11,9 @@ using Lambdy.TreeNodes.ClauseSectionNodes.Abstract;
 namespace Lambdy.Builders
 {
     internal sealed class LambdyBuilder<TModel> : ILambdyBuilder<TModel> 
-        where TModel: class
+        where TModel : class
     {
-        private string _customTemplate;
+        private string? _customTemplate;
         
         private readonly QueryCompiler _queryCompiler;
         
@@ -35,7 +35,7 @@ namespace Lambdy.Builders
 
         internal LambdyBuilder(QueryCompiler queryCompiler)
         {
-            _queryCompiler = queryCompiler;
+            _queryCompiler = queryCompiler ?? throw new ArgumentNullException(nameof(queryCompiler));
             _clauseSectionNodes[0] = _selectClause;
             _clauseSectionNodes[1] = _fromClause;
             _clauseSectionNodes[2] = _joinClause;
@@ -67,7 +67,7 @@ namespace Lambdy.Builders
                 });
         }
 
-        public ILambdyBuilder<TModel> WithTemplate(string sqlTemplate)
+        public ILambdyBuilder<TModel> WithTemplate(string? sqlTemplate)
         {
             _customTemplate = sqlTemplate;
             return this;
@@ -103,7 +103,7 @@ namespace Lambdy.Builders
             });
         }
         
-        public LambdyResult Compile(LambdyCompilerOptions options)
+        public LambdyResult Compile(LambdyCompilerOptions? options = null)
         {
             return _queryCompiler.Compile(new QueryCompilerInput()
             {
@@ -111,7 +111,7 @@ namespace Lambdy.Builders
                 SqlTemplate = _customTemplate,
                 ParameterTracker = _parameterTracker,
                 ClauseNodes = _clauseSectionNodes,
-                RemoveEmptyTokens = options.RemoveEmptyTokens
+                RemoveEmptyTokens = options?.RemoveEmptyTokens ?? true
             });
         }
         

--- a/Lambdy/Builders/LambdyBuilder.cs
+++ b/Lambdy/Builders/LambdyBuilder.cs
@@ -1,4 +1,5 @@
-﻿using Lambdy.Builders.SubBuilders.Expressions;
+﻿using System;
+using Lambdy.Builders.SubBuilders.Expressions;
 using Lambdy.Builders.SubBuilders.Expressions.Interfaces;
 using Lambdy.Builders.SubBuilders.Raw;
 using Lambdy.Builders.SubBuilders.Raw.Interfaces;

--- a/Lambdy/Builders/SubBuilders/Expressions/ExpressionBuilder.cs
+++ b/Lambdy/Builders/SubBuilders/Expressions/ExpressionBuilder.cs
@@ -19,7 +19,7 @@ namespace Lambdy.Builders.SubBuilders.Expressions
         
         public void AddSelectExpression(System.Linq.Expressions.Expression exprBody)
         {
-            ArgumentNullException.ThrowIfNull(exprBody);
+            if (exprBody is null) throw new ArgumentNullException(nameof(exprBody));
             
             _clauseReferences.SelectClause.Node = ExpressionResolverMediator
                 .ResolveExpression(exprBody);
@@ -27,7 +27,7 @@ namespace Lambdy.Builders.SubBuilders.Expressions
         
         public void AddWhereExpression(System.Linq.Expressions.Expression exprBody)
         {
-            ArgumentNullException.ThrowIfNull(exprBody);
+            if (exprBody is null) throw new ArgumentNullException(nameof(exprBody));
             
             _clauseReferences.WhereClause.Nodes
                 .Add(ExpressionResolverMediator.ResolveExpression(exprBody));
@@ -35,7 +35,7 @@ namespace Lambdy.Builders.SubBuilders.Expressions
 
         public void AddOrderByExpression(System.Linq.Expressions.Expression exprBody)
         {
-            ArgumentNullException.ThrowIfNull(exprBody);
+            if (exprBody is null) throw new ArgumentNullException(nameof(exprBody));
             
             _clauseReferences.OrderClause.Nodes = new List<OrderClauseEntryNode>()
             {
@@ -49,7 +49,7 @@ namespace Lambdy.Builders.SubBuilders.Expressions
         
         public void AddThenByExpression(System.Linq.Expressions.Expression exprBody)
         {
-            ArgumentNullException.ThrowIfNull(exprBody);
+            if (exprBody is null) throw new ArgumentNullException(nameof(exprBody));
             
             _clauseReferences.OrderClause.Nodes.Add(new OrderClauseEntryNode()
             {
@@ -60,7 +60,7 @@ namespace Lambdy.Builders.SubBuilders.Expressions
         
         public void AddOrderByDescExpression(System.Linq.Expressions.Expression exprBody)
         {
-            ArgumentNullException.ThrowIfNull(exprBody);
+            if (exprBody is null) throw new ArgumentNullException(nameof(exprBody));
             
             _clauseReferences.OrderClause.Nodes = new List<OrderClauseEntryNode>()
             {
@@ -74,7 +74,7 @@ namespace Lambdy.Builders.SubBuilders.Expressions
         
         public void AddThenByDescExpression(System.Linq.Expressions.Expression exprBody)
         {
-            ArgumentNullException.ThrowIfNull(exprBody);
+            if (exprBody is null) throw new ArgumentNullException(nameof(exprBody));
             
             _clauseReferences.OrderClause.Nodes.Add(new OrderClauseEntryNode()
             {

--- a/Lambdy/Builders/SubBuilders/Expressions/ExpressionBuilder.cs
+++ b/Lambdy/Builders/SubBuilders/Expressions/ExpressionBuilder.cs
@@ -14,12 +14,12 @@ namespace Lambdy.Builders.SubBuilders.Expressions
         public ExpressionBuilder(
             ExpressionBuilderClauseReferences clauseReferences)
         {
-            _clauseReferences = clauseReferences ?? throw new ArgumentNullException(nameof(clauseReferences));
+            _clauseReferences = clauseReferences.ThrowIfNull(nameof(clauseReferences));
         }
         
         public void AddSelectExpression(System.Linq.Expressions.Expression exprBody)
         {
-            if (exprBody is null) throw new ArgumentNullException(nameof(exprBody));
+            exprBody.ThrowIfNull(nameof(exprBody));
             
             _clauseReferences.SelectClause.Node = ExpressionResolverMediator
                 .ResolveExpression(exprBody);
@@ -27,7 +27,7 @@ namespace Lambdy.Builders.SubBuilders.Expressions
         
         public void AddWhereExpression(System.Linq.Expressions.Expression exprBody)
         {
-            if (exprBody is null) throw new ArgumentNullException(nameof(exprBody));
+            exprBody.ThrowIfNull(nameof(exprBody));
             
             _clauseReferences.WhereClause.Nodes
                 .Add(ExpressionResolverMediator.ResolveExpression(exprBody));
@@ -35,7 +35,7 @@ namespace Lambdy.Builders.SubBuilders.Expressions
 
         public void AddOrderByExpression(System.Linq.Expressions.Expression exprBody)
         {
-            if (exprBody is null) throw new ArgumentNullException(nameof(exprBody));
+            exprBody.ThrowIfNull(nameof(exprBody));
             
             _clauseReferences.OrderClause.Nodes = new List<OrderClauseEntryNode>()
             {
@@ -49,7 +49,7 @@ namespace Lambdy.Builders.SubBuilders.Expressions
         
         public void AddThenByExpression(System.Linq.Expressions.Expression exprBody)
         {
-            if (exprBody is null) throw new ArgumentNullException(nameof(exprBody));
+            exprBody.ThrowIfNull(nameof(exprBody));
             
             _clauseReferences.OrderClause.Nodes.Add(new OrderClauseEntryNode()
             {
@@ -60,7 +60,7 @@ namespace Lambdy.Builders.SubBuilders.Expressions
         
         public void AddOrderByDescExpression(System.Linq.Expressions.Expression exprBody)
         {
-            if (exprBody is null) throw new ArgumentNullException(nameof(exprBody));
+            exprBody.ThrowIfNull(nameof(exprBody));
             
             _clauseReferences.OrderClause.Nodes = new List<OrderClauseEntryNode>()
             {
@@ -74,7 +74,7 @@ namespace Lambdy.Builders.SubBuilders.Expressions
         
         public void AddThenByDescExpression(System.Linq.Expressions.Expression exprBody)
         {
-            if (exprBody is null) throw new ArgumentNullException(nameof(exprBody));
+            exprBody.ThrowIfNull(nameof(exprBody));
             
             _clauseReferences.OrderClause.Nodes.Add(new OrderClauseEntryNode()
             {

--- a/Lambdy/Builders/SubBuilders/Expressions/ExpressionBuilder.cs
+++ b/Lambdy/Builders/SubBuilders/Expressions/ExpressionBuilder.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Lambdy.Builders.SubBuilders.Expressions.Interfaces;
 using Lambdy.Resolvers;
 using Lambdy.TreeNodes.ClauseSectionNodes;
@@ -13,23 +14,29 @@ namespace Lambdy.Builders.SubBuilders.Expressions
         public ExpressionBuilder(
             ExpressionBuilderClauseReferences clauseReferences)
         {
-            _clauseReferences = clauseReferences;
+            _clauseReferences = clauseReferences ?? throw new ArgumentNullException(nameof(clauseReferences));
         }
         
         public void AddSelectExpression(System.Linq.Expressions.Expression exprBody)
         {
+            ArgumentNullException.ThrowIfNull(exprBody);
+            
             _clauseReferences.SelectClause.Node = ExpressionResolverMediator
                 .ResolveExpression(exprBody);
         }
         
         public void AddWhereExpression(System.Linq.Expressions.Expression exprBody)
         {
+            ArgumentNullException.ThrowIfNull(exprBody);
+            
             _clauseReferences.WhereClause.Nodes
                 .Add(ExpressionResolverMediator.ResolveExpression(exprBody));
         }
 
         public void AddOrderByExpression(System.Linq.Expressions.Expression exprBody)
         {
+            ArgumentNullException.ThrowIfNull(exprBody);
+            
             _clauseReferences.OrderClause.Nodes = new List<OrderClauseEntryNode>()
             {
                 new OrderClauseEntryNode()
@@ -42,6 +49,8 @@ namespace Lambdy.Builders.SubBuilders.Expressions
         
         public void AddThenByExpression(System.Linq.Expressions.Expression exprBody)
         {
+            ArgumentNullException.ThrowIfNull(exprBody);
+            
             _clauseReferences.OrderClause.Nodes.Add(new OrderClauseEntryNode()
             {
                 Direction = OrderDirection.Asc,
@@ -51,6 +60,8 @@ namespace Lambdy.Builders.SubBuilders.Expressions
         
         public void AddOrderByDescExpression(System.Linq.Expressions.Expression exprBody)
         {
+            ArgumentNullException.ThrowIfNull(exprBody);
+            
             _clauseReferences.OrderClause.Nodes = new List<OrderClauseEntryNode>()
             {
                 new OrderClauseEntryNode()
@@ -63,6 +74,8 @@ namespace Lambdy.Builders.SubBuilders.Expressions
         
         public void AddThenByDescExpression(System.Linq.Expressions.Expression exprBody)
         {
+            ArgumentNullException.ThrowIfNull(exprBody);
+            
             _clauseReferences.OrderClause.Nodes.Add(new OrderClauseEntryNode()
             {
                 Direction = OrderDirection.Desc,

--- a/Lambdy/Builders/SubBuilders/Expressions/ExpressionBuilderClauseReferences.cs
+++ b/Lambdy/Builders/SubBuilders/Expressions/ExpressionBuilderClauseReferences.cs
@@ -4,11 +4,11 @@ namespace Lambdy.Builders.SubBuilders.Expressions
 {
     internal class ExpressionBuilderClauseReferences
     {
-        public SelectClauseNode? SelectClause { get; set; }
-        public FromClauseNode? FromClause { get; set; }
-        public JoinClauseNode? JoinClause { get; set; }
-        public WhereClauseNode? WhereClause { get; set; }
-        public OrderClauseNode? OrderClause { get; set; }
-        public SkipTakeClauseNode? SkipTakeClause  { get; set; }
+        public SelectClauseNode SelectClause { get; set; } = new SelectClauseNode();
+        public FromClauseNode FromClause { get; set; } = new FromClauseNode();
+        public JoinClauseNode JoinClause { get; set; } = new JoinClauseNode();
+        public WhereClauseNode WhereClause { get; set; } = new WhereClauseNode();
+        public OrderClauseNode OrderClause { get; set; } = new OrderClauseNode();
+        public SkipTakeClauseNode SkipTakeClause  { get; set; } = new SkipTakeClauseNode();
     }
 }

--- a/Lambdy/Builders/SubBuilders/Expressions/ExpressionBuilderClauseReferences.cs
+++ b/Lambdy/Builders/SubBuilders/Expressions/ExpressionBuilderClauseReferences.cs
@@ -4,11 +4,11 @@ namespace Lambdy.Builders.SubBuilders.Expressions
 {
     internal class ExpressionBuilderClauseReferences
     {
-        public SelectClauseNode SelectClause { get; set; }
-        public FromClauseNode FromClause { get; set; }
-        public JoinClauseNode JoinClause { get; set; }
-        public WhereClauseNode WhereClause { get; set; }
-        public OrderClauseNode OrderClause { get; set; }
-        public SkipTakeClauseNode SkipTakeClause  { get; set; }
+        public SelectClauseNode? SelectClause { get; set; }
+        public FromClauseNode? FromClause { get; set; }
+        public JoinClauseNode? JoinClause { get; set; }
+        public WhereClauseNode? WhereClause { get; set; }
+        public OrderClauseNode? OrderClause { get; set; }
+        public SkipTakeClauseNode? SkipTakeClause  { get; set; }
     }
 }

--- a/Lambdy/Builders/SubBuilders/Raw/RawBuilder.cs
+++ b/Lambdy/Builders/SubBuilders/Raw/RawBuilder.cs
@@ -28,7 +28,7 @@ namespace Lambdy.Builders.SubBuilders.Raw
 
         public ILambdyBuilder<TModel> From(string sqlFragment)
         {
-            ArgumentNullException.ThrowIfNull(sqlFragment);
+            if (sqlFragment is null) throw new ArgumentNullException(nameof(sqlFragment));
             
             sqlFragment = SubstringSqlClause(sqlFragment, SqlClauses.From);
 
@@ -41,7 +41,7 @@ namespace Lambdy.Builders.SubBuilders.Raw
 
         public ILambdyBuilder<TModel> Join(string sqlFragment)
         {
-            ArgumentNullException.ThrowIfNull(sqlFragment);
+            if (sqlFragment is null) throw new ArgumentNullException(nameof(sqlFragment));
             
             _clauseReferences
                 .JoinClause
@@ -53,7 +53,7 @@ namespace Lambdy.Builders.SubBuilders.Raw
 
         public ILambdyBuilder<TModel> Where(string sqlFragment)
         {
-            ArgumentNullException.ThrowIfNull(sqlFragment);
+            if (sqlFragment is null) throw new ArgumentNullException(nameof(sqlFragment));
             
             _clauseReferences
                 .WhereClause
@@ -67,8 +67,8 @@ namespace Lambdy.Builders.SubBuilders.Raw
             string sqlFragment,
             object parameters)
         {
-            ArgumentNullException.ThrowIfNull(sqlFragment);
-            ArgumentNullException.ThrowIfNull(parameters);
+            if (sqlFragment is null) throw new ArgumentNullException(nameof(sqlFragment));
+            if (parameters is null) throw new ArgumentNullException(nameof(parameters));
             
             Where(sqlFragment);
             AppendParametersFromObject(parameters);
@@ -78,7 +78,7 @@ namespace Lambdy.Builders.SubBuilders.Raw
 
         public ILambdyBuilder<TModel> OrderBy(string sqlFragment)
         {
-            ArgumentNullException.ThrowIfNull(sqlFragment);
+            if (sqlFragment is null) throw new ArgumentNullException(nameof(sqlFragment));
             
             sqlFragment = SubstringSqlClause(sqlFragment, SqlClauses.OrderBy);
 
@@ -99,8 +99,8 @@ namespace Lambdy.Builders.SubBuilders.Raw
             string sqlFragment,
             object parameters)
         {
-            ArgumentNullException.ThrowIfNull(sqlFragment);
-            ArgumentNullException.ThrowIfNull(parameters);
+            if (sqlFragment is null) throw new ArgumentNullException(nameof(sqlFragment));
+            if (parameters is null) throw new ArgumentNullException(nameof(parameters));
             
             OrderBy(sqlFragment);
             AppendParametersFromObject(parameters);
@@ -110,8 +110,8 @@ namespace Lambdy.Builders.SubBuilders.Raw
 
         private string SubstringSqlClause(string sqlFragment, string clause)
         {
-            ArgumentNullException.ThrowIfNull(sqlFragment);
-            ArgumentNullException.ThrowIfNull(clause);
+            if (sqlFragment is null) throw new ArgumentNullException(nameof(sqlFragment));
+            if (clause is null) throw new ArgumentNullException(nameof(clause));
             
             var index = sqlFragment.IndexOf(
                 clause,
@@ -128,7 +128,7 @@ namespace Lambdy.Builders.SubBuilders.Raw
 
         private void AppendParametersFromObject(object parameters)
         {
-            ArgumentNullException.ThrowIfNull(parameters);
+            if (parameters is null) throw new ArgumentNullException(nameof(parameters));
 
             foreach (PropertyDescriptor property in TypeDescriptor.GetProperties(parameters))
             {

--- a/Lambdy/Builders/SubBuilders/Raw/RawBuilder.cs
+++ b/Lambdy/Builders/SubBuilders/Raw/RawBuilder.cs
@@ -10,7 +10,7 @@ using Lambdy.TreeNodes.ExpressionNodes;
 namespace Lambdy.Builders.SubBuilders.Raw
 {
     internal class RawBuilder<TModel> : IRawBuilder<TModel>
-        where TModel: class
+        where TModel : class
     {
         private readonly ILambdyBuilder<TModel> _parentBuilder;
         private readonly ParameterTracker _parentParameterTracker;
@@ -21,13 +21,15 @@ namespace Lambdy.Builders.SubBuilders.Raw
             ParameterTracker parameterTracker,
             RawBuilderClauseReferences references)
         {
-            _parentBuilder = parentBuilder;
-            _parentParameterTracker = parameterTracker;
-            _clauseReferences = references;
+            _parentBuilder = parentBuilder ?? throw new ArgumentNullException(nameof(parentBuilder));
+            _parentParameterTracker = parameterTracker ?? throw new ArgumentNullException(nameof(parameterTracker));
+            _clauseReferences = references ?? throw new ArgumentNullException(nameof(references));
         }
 
         public ILambdyBuilder<TModel> From(string sqlFragment)
         {
+            ArgumentNullException.ThrowIfNull(sqlFragment);
+            
             sqlFragment = SubstringSqlClause(sqlFragment, SqlClauses.From);
 
             _clauseReferences
@@ -39,6 +41,8 @@ namespace Lambdy.Builders.SubBuilders.Raw
 
         public ILambdyBuilder<TModel> Join(string sqlFragment)
         {
+            ArgumentNullException.ThrowIfNull(sqlFragment);
+            
             _clauseReferences
                 .JoinClause
                 .Nodes
@@ -47,9 +51,10 @@ namespace Lambdy.Builders.SubBuilders.Raw
             return _parentBuilder;
         }
 
-        public ILambdyBuilder<TModel> Where(
-            string sqlFragment)
+        public ILambdyBuilder<TModel> Where(string sqlFragment)
         {
+            ArgumentNullException.ThrowIfNull(sqlFragment);
+            
             _clauseReferences
                 .WhereClause
                 .Nodes
@@ -62,15 +67,19 @@ namespace Lambdy.Builders.SubBuilders.Raw
             string sqlFragment,
             object parameters)
         {
+            ArgumentNullException.ThrowIfNull(sqlFragment);
+            ArgumentNullException.ThrowIfNull(parameters);
+            
             Where(sqlFragment);
             AppendParametersFromObject(parameters);
 
             return _parentBuilder;
         }
 
-        public ILambdyBuilder<TModel> OrderBy(
-            string sqlFragment)
+        public ILambdyBuilder<TModel> OrderBy(string sqlFragment)
         {
+            ArgumentNullException.ThrowIfNull(sqlFragment);
+            
             sqlFragment = SubstringSqlClause(sqlFragment, SqlClauses.OrderBy);
 
             _clauseReferences
@@ -90,6 +99,9 @@ namespace Lambdy.Builders.SubBuilders.Raw
             string sqlFragment,
             object parameters)
         {
+            ArgumentNullException.ThrowIfNull(sqlFragment);
+            ArgumentNullException.ThrowIfNull(parameters);
+            
             OrderBy(sqlFragment);
             AppendParametersFromObject(parameters);
 
@@ -98,6 +110,9 @@ namespace Lambdy.Builders.SubBuilders.Raw
 
         private string SubstringSqlClause(string sqlFragment, string clause)
         {
+            ArgumentNullException.ThrowIfNull(sqlFragment);
+            ArgumentNullException.ThrowIfNull(clause);
+            
             var index = sqlFragment.IndexOf(
                 clause,
                 StringComparison.InvariantCultureIgnoreCase);
@@ -113,16 +128,16 @@ namespace Lambdy.Builders.SubBuilders.Raw
 
         private void AppendParametersFromObject(object parameters)
         {
-            if (parameters == null)
-            {
-                throw new ArgumentNullException($"{nameof(parameters)} cannot be null!");
-            }
+            ArgumentNullException.ThrowIfNull(parameters);
 
             foreach (PropertyDescriptor property in TypeDescriptor.GetProperties(parameters))
             {
                 var value = property.GetValue(parameters);
-                _parentParameterTracker
-                    .AddParameter(property.Name, value);
+                if (value != null)
+                {
+                    _parentParameterTracker
+                        .AddParameter(property.Name, value);
+                }
             }
         }
     }

--- a/Lambdy/Builders/SubBuilders/Raw/RawBuilder.cs
+++ b/Lambdy/Builders/SubBuilders/Raw/RawBuilder.cs
@@ -21,14 +21,14 @@ namespace Lambdy.Builders.SubBuilders.Raw
             ParameterTracker parameterTracker,
             RawBuilderClauseReferences references)
         {
-            _parentBuilder = parentBuilder ?? throw new ArgumentNullException(nameof(parentBuilder));
-            _parentParameterTracker = parameterTracker ?? throw new ArgumentNullException(nameof(parameterTracker));
-            _clauseReferences = references ?? throw new ArgumentNullException(nameof(references));
+            _parentBuilder = parentBuilder.ThrowIfNull(nameof(parentBuilder));
+            _parentParameterTracker = parameterTracker.ThrowIfNull(nameof(parameterTracker));
+            _clauseReferences = references.ThrowIfNull(nameof(references));
         }
 
         public ILambdyBuilder<TModel> From(string sqlFragment)
         {
-            if (sqlFragment is null) throw new ArgumentNullException(nameof(sqlFragment));
+            sqlFragment.ThrowIfNull(nameof(sqlFragment));
             
             sqlFragment = SubstringSqlClause(sqlFragment, SqlClauses.From);
 
@@ -41,7 +41,7 @@ namespace Lambdy.Builders.SubBuilders.Raw
 
         public ILambdyBuilder<TModel> Join(string sqlFragment)
         {
-            if (sqlFragment is null) throw new ArgumentNullException(nameof(sqlFragment));
+            sqlFragment.ThrowIfNull(nameof(sqlFragment));
             
             _clauseReferences
                 .JoinClause
@@ -53,7 +53,7 @@ namespace Lambdy.Builders.SubBuilders.Raw
 
         public ILambdyBuilder<TModel> Where(string sqlFragment)
         {
-            if (sqlFragment is null) throw new ArgumentNullException(nameof(sqlFragment));
+            sqlFragment.ThrowIfNull(nameof(sqlFragment));
             
             _clauseReferences
                 .WhereClause
@@ -67,8 +67,8 @@ namespace Lambdy.Builders.SubBuilders.Raw
             string sqlFragment,
             object parameters)
         {
-            if (sqlFragment is null) throw new ArgumentNullException(nameof(sqlFragment));
-            if (parameters is null) throw new ArgumentNullException(nameof(parameters));
+            sqlFragment.ThrowIfNull(nameof(sqlFragment));
+            parameters.ThrowIfNull(nameof(parameters));
             
             Where(sqlFragment);
             AppendParametersFromObject(parameters);
@@ -78,7 +78,7 @@ namespace Lambdy.Builders.SubBuilders.Raw
 
         public ILambdyBuilder<TModel> OrderBy(string sqlFragment)
         {
-            if (sqlFragment is null) throw new ArgumentNullException(nameof(sqlFragment));
+            sqlFragment.ThrowIfNull(nameof(sqlFragment));
             
             sqlFragment = SubstringSqlClause(sqlFragment, SqlClauses.OrderBy);
 
@@ -99,8 +99,8 @@ namespace Lambdy.Builders.SubBuilders.Raw
             string sqlFragment,
             object parameters)
         {
-            if (sqlFragment is null) throw new ArgumentNullException(nameof(sqlFragment));
-            if (parameters is null) throw new ArgumentNullException(nameof(parameters));
+            sqlFragment.ThrowIfNull(nameof(sqlFragment));
+            parameters.ThrowIfNull(nameof(parameters));
             
             OrderBy(sqlFragment);
             AppendParametersFromObject(parameters);
@@ -110,8 +110,8 @@ namespace Lambdy.Builders.SubBuilders.Raw
 
         private string SubstringSqlClause(string sqlFragment, string clause)
         {
-            if (sqlFragment is null) throw new ArgumentNullException(nameof(sqlFragment));
-            if (clause is null) throw new ArgumentNullException(nameof(clause));
+            sqlFragment.ThrowIfNull(nameof(sqlFragment));
+            clause.ThrowIfNull(nameof(clause));
             
             var index = sqlFragment.IndexOf(
                 clause,
@@ -128,7 +128,7 @@ namespace Lambdy.Builders.SubBuilders.Raw
 
         private void AppendParametersFromObject(object parameters)
         {
-            if (parameters is null) throw new ArgumentNullException(nameof(parameters));
+            parameters.ThrowIfNull(nameof(parameters));
 
             foreach (PropertyDescriptor property in TypeDescriptor.GetProperties(parameters))
             {

--- a/Lambdy/Builders/SubBuilders/Raw/RawBuilderClauseReferences.cs
+++ b/Lambdy/Builders/SubBuilders/Raw/RawBuilderClauseReferences.cs
@@ -6,11 +6,11 @@ namespace Lambdy.Builders.SubBuilders.Raw
 {
     internal class RawBuilderClauseReferences
     {
-        public SelectClauseNode SelectClause { get; set; }
-        public FromClauseNode FromClause { get; set; }
-        public JoinClauseNode JoinClause { get; set; }
-        public WhereClauseNode WhereClause { get; set; }
-        public OrderClauseNode OrderClause { get; set; }
-        public SkipTakeClauseNode SkipTakeClause  { get; set; }
+        public SelectClauseNode? SelectClause { get; set; }
+        public FromClauseNode? FromClause { get; set; }
+        public JoinClauseNode? JoinClause { get; set; }
+        public WhereClauseNode? WhereClause { get; set; }
+        public OrderClauseNode? OrderClause { get; set; }
+        public SkipTakeClauseNode? SkipTakeClause  { get; set; }
     }
 }

--- a/Lambdy/Builders/SubBuilders/Raw/RawBuilderClauseReferences.cs
+++ b/Lambdy/Builders/SubBuilders/Raw/RawBuilderClauseReferences.cs
@@ -6,11 +6,11 @@ namespace Lambdy.Builders.SubBuilders.Raw
 {
     internal class RawBuilderClauseReferences
     {
-        public SelectClauseNode? SelectClause { get; set; }
-        public FromClauseNode? FromClause { get; set; }
-        public JoinClauseNode? JoinClause { get; set; }
-        public WhereClauseNode? WhereClause { get; set; }
-        public OrderClauseNode? OrderClause { get; set; }
-        public SkipTakeClauseNode? SkipTakeClause  { get; set; }
+        public SelectClauseNode SelectClause { get; set; } = new SelectClauseNode();
+        public FromClauseNode FromClause { get; set; } = new FromClauseNode();
+        public JoinClauseNode JoinClause { get; set; } = new JoinClauseNode();
+        public WhereClauseNode WhereClause { get; set; } = new WhereClauseNode();
+        public OrderClauseNode OrderClause { get; set; } = new OrderClauseNode();
+        public SkipTakeClauseNode SkipTakeClause  { get; set; } = new SkipTakeClauseNode();
     }
 }

--- a/Lambdy/Compilers/Query/Input/QueryCompilerInput.cs
+++ b/Lambdy/Compilers/Query/Input/QueryCompilerInput.cs
@@ -7,13 +7,13 @@ namespace Lambdy.Compilers.Query.Input
     {
         public LambdySqlDialect SqlDialect { get; set; }
         
-        public string SqlTemplate { get; set; }
+        public string? SqlTemplate { get; set; }
 
-        public ParameterTracker ParameterTracker { get; set; }
+        public ParameterTracker ParameterTracker { get; set; } = new ParameterTracker();
         
-        public ClauseSectionNode[] ClauseNodes { get; set; }
+        public ClauseSectionNode[] ClauseNodes { get; set; } = Array.Empty<ClauseSectionNode>();
         
-        public bool RemoveEmptyTokens { get; set; }
+        public bool RemoveEmptyTokens { get; set; } = true;
         
     }
 }

--- a/Lambdy/Compilers/Query/Input/QueryCompilerInput.cs
+++ b/Lambdy/Compilers/Query/Input/QueryCompilerInput.cs
@@ -1,4 +1,5 @@
-﻿using Lambdy.Parameters;
+﻿using System;
+using Lambdy.Parameters;
 using Lambdy.TreeNodes.ClauseSectionNodes.Abstract;
 
 namespace Lambdy.Compilers.Query.Input
@@ -9,9 +10,9 @@ namespace Lambdy.Compilers.Query.Input
         
         public string? SqlTemplate { get; set; }
 
-        public ParameterTracker ParameterTracker { get; set; } = new ParameterTracker();
+        public ParameterTracker? ParameterTracker { get; set; } = new ParameterTracker();
         
-        public ClauseSectionNode[] ClauseNodes { get; set; } = Array.Empty<ClauseSectionNode>();
+        public ClauseSectionNode[]? ClauseNodes { get; set; } = Array.Empty<ClauseSectionNode>();
         
         public bool RemoveEmptyTokens { get; set; } = true;
         

--- a/Lambdy/Compilers/Query/RecursiveQueryCompiler.cs
+++ b/Lambdy/Compilers/Query/RecursiveQueryCompiler.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using System;
+using System.Text;
 using Lambdy.Compilers.Query.Abstract;
 using Lambdy.Compilers.Query.Input;
 using Lambdy.Visitors.ClauseSectionSql;
@@ -10,6 +11,10 @@ namespace Lambdy.Compilers.Query
     {
         public override LambdyResult Compile(QueryCompilerInput queryCompilerInput)
         {
+            ArgumentNullException.ThrowIfNull(queryCompilerInput);
+            ArgumentNullException.ThrowIfNull(queryCompilerInput.ParameterTracker);
+            ArgumentNullException.ThrowIfNull(queryCompilerInput.ClauseNodes);
+
             var stringBuilder = new StringBuilder();
             var expressionNodeSqlVisitor = new RecursiveNodeSqlVisitor(stringBuilder);
             var clauseSectionSqlVisitor = new RecursiveClauseSectionSqlVisitor(

--- a/Lambdy/Compilers/Query/RecursiveQueryCompiler.cs
+++ b/Lambdy/Compilers/Query/RecursiveQueryCompiler.cs
@@ -11,9 +11,9 @@ namespace Lambdy.Compilers.Query
     {
         public override LambdyResult Compile(QueryCompilerInput queryCompilerInput)
         {
-            if (queryCompilerInput is null) throw new ArgumentNullException(nameof(queryCompilerInput));
-            if (queryCompilerInput.ParameterTracker is null) throw new ArgumentNullException(nameof(queryCompilerInput.ParameterTracker));
-            if (queryCompilerInput.ClauseNodes is null) throw new ArgumentNullException(nameof(queryCompilerInput.ClauseNodes));
+            queryCompilerInput.ThrowIfNull(nameof(queryCompilerInput));
+            queryCompilerInput.ParameterTracker.ThrowIfNull(nameof(queryCompilerInput.ParameterTracker));
+            queryCompilerInput.ClauseNodes.ThrowIfNull(nameof(queryCompilerInput.ClauseNodes));
 
             var stringBuilder = new StringBuilder();
             var expressionNodeSqlVisitor = new RecursiveNodeSqlVisitor(stringBuilder);

--- a/Lambdy/Compilers/Query/RecursiveQueryCompiler.cs
+++ b/Lambdy/Compilers/Query/RecursiveQueryCompiler.cs
@@ -24,10 +24,10 @@ namespace Lambdy.Compilers.Query
                 queryCompilerInput.RemoveEmptyTokens);
 
             clauseSectionSqlVisitor.SetTemplate(queryCompilerInput.SqlTemplate!);
-            expressionNodeSqlVisitor.SetParameterTracker(queryCompilerInput.ParameterTracker);
+            expressionNodeSqlVisitor.SetParameterTracker(queryCompilerInput.ParameterTracker!);
 
             // ReSharper disable once ForCanBeConvertedToForeach (reason - performance)
-            for (var i = 0; i < queryCompilerInput.ClauseNodes.Length; i++)
+            for (var i = 0; i < queryCompilerInput.ClauseNodes!.Length; i++)
             {
                 queryCompilerInput
                     .ClauseNodes[i]
@@ -37,7 +37,7 @@ namespace Lambdy.Compilers.Query
             return new LambdyResult
             {
                 Sql = clauseSectionSqlVisitor.Sql,
-                Parameters = expressionNodeSqlVisitor.ParameterTracker.Parameters
+                Parameters = expressionNodeSqlVisitor.ParameterTracker!.Parameters
             };
         }
     }

--- a/Lambdy/Compilers/Query/RecursiveQueryCompiler.cs
+++ b/Lambdy/Compilers/Query/RecursiveQueryCompiler.cs
@@ -11,9 +11,9 @@ namespace Lambdy.Compilers.Query
     {
         public override LambdyResult Compile(QueryCompilerInput queryCompilerInput)
         {
-            ArgumentNullException.ThrowIfNull(queryCompilerInput);
-            ArgumentNullException.ThrowIfNull(queryCompilerInput.ParameterTracker);
-            ArgumentNullException.ThrowIfNull(queryCompilerInput.ClauseNodes);
+            if (queryCompilerInput is null) throw new ArgumentNullException(nameof(queryCompilerInput));
+            if (queryCompilerInput.ParameterTracker is null) throw new ArgumentNullException(nameof(queryCompilerInput.ParameterTracker));
+            if (queryCompilerInput.ClauseNodes is null) throw new ArgumentNullException(nameof(queryCompilerInput.ClauseNodes));
 
             var stringBuilder = new StringBuilder();
             var expressionNodeSqlVisitor = new RecursiveNodeSqlVisitor(stringBuilder);
@@ -23,7 +23,7 @@ namespace Lambdy.Compilers.Query
                 queryCompilerInput.SqlDialect,
                 queryCompilerInput.RemoveEmptyTokens);
 
-            clauseSectionSqlVisitor.SetTemplate(queryCompilerInput.SqlTemplate);
+            clauseSectionSqlVisitor.SetTemplate(queryCompilerInput.SqlTemplate!);
             expressionNodeSqlVisitor.SetParameterTracker(queryCompilerInput.ParameterTracker);
 
             // ReSharper disable once ForCanBeConvertedToForeach (reason - performance)

--- a/Lambdy/ILambdyBuilder.cs
+++ b/Lambdy/ILambdyBuilder.cs
@@ -3,7 +3,7 @@
 namespace Lambdy
 {
     public interface ILambdyBuilder<out TModel> : ILambdyBuilderCore
-        where TModel: class
+        where TModel : class
     {
         IRawBuilder<TModel> Raw { get; }
 

--- a/Lambdy/ILambdyBuilderCore.cs
+++ b/Lambdy/ILambdyBuilderCore.cs
@@ -8,6 +8,6 @@ namespace Lambdy
 
         LambdyResult Compile();
 
-        LambdyResult Compile(LambdyCompilerOptions options);
+        LambdyResult Compile(LambdyCompilerOptions? options = null);
     }
 }

--- a/Lambdy/Lambdy.csproj
+++ b/Lambdy/Lambdy.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFramework>netstandard2.1</TargetFramework>
+        <Nullable>enable</Nullable>
         <PackageId>Lambdy</PackageId>
         <Authors>Vladimir Belyayev</Authors>
         <PackageDescription>Library for building SQL from Lambda expressions, for use in conjunction with Micro-ORMs</PackageDescription>

--- a/Lambdy/LambdyBuilderCoreExtensions.cs
+++ b/Lambdy/LambdyBuilderCoreExtensions.cs
@@ -1,4 +1,6 @@
-﻿namespace Lambdy
+﻿using System;
+
+namespace Lambdy
 {
     public static class LambdyBuilderCoreExtensions
     {
@@ -6,6 +8,7 @@
             this ILambdyBuilderCore lambdyBuilder)
             where TTarget : class
         {
+            ArgumentNullException.ThrowIfNull(lambdyBuilder);
             return (ILambdyBuilder<TTarget>) lambdyBuilder;
         }
     }

--- a/Lambdy/LambdyBuilderCoreExtensions.cs
+++ b/Lambdy/LambdyBuilderCoreExtensions.cs
@@ -8,7 +8,7 @@ namespace Lambdy
             this ILambdyBuilderCore lambdyBuilder)
             where TTarget : class
         {
-            if (lambdyBuilder is null) throw new ArgumentNullException(nameof(lambdyBuilder));
+            lambdyBuilder.ThrowIfNull(nameof(lambdyBuilder));
             return (ILambdyBuilder<TTarget>) lambdyBuilder;
         }
     }

--- a/Lambdy/LambdyBuilderCoreExtensions.cs
+++ b/Lambdy/LambdyBuilderCoreExtensions.cs
@@ -8,7 +8,7 @@ namespace Lambdy
             this ILambdyBuilderCore lambdyBuilder)
             where TTarget : class
         {
-            ArgumentNullException.ThrowIfNull(lambdyBuilder);
+            if (lambdyBuilder is null) throw new ArgumentNullException(nameof(lambdyBuilder));
             return (ILambdyBuilder<TTarget>) lambdyBuilder;
         }
     }

--- a/Lambdy/LambdyBuilderExtensions.cs
+++ b/Lambdy/LambdyBuilderExtensions.cs
@@ -10,8 +10,8 @@ namespace Lambdy
             Expression<Func<TModel, TSelectModel>> expression)
             where TModel : class
         {
-            ArgumentNullException.ThrowIfNull(lambdyBuilder);
-            ArgumentNullException.ThrowIfNull(expression);
+            if (lambdyBuilder is null) throw new ArgumentNullException(nameof(lambdyBuilder));
+            if (expression is null) throw new ArgumentNullException(nameof(expression));
             
             lambdyBuilder
                 .ExpressionBuilder
@@ -24,8 +24,8 @@ namespace Lambdy
             Expression<Func<TModel, bool>> expression) 
             where TModel : class
         {
-            ArgumentNullException.ThrowIfNull(lambdyBuilder);
-            ArgumentNullException.ThrowIfNull(expression);
+            if (lambdyBuilder is null) throw new ArgumentNullException(nameof(lambdyBuilder));
+            if (expression is null) throw new ArgumentNullException(nameof(expression));
             
             lambdyBuilder
                 .ExpressionBuilder
@@ -38,8 +38,8 @@ namespace Lambdy
             Expression<Func<TModel, TKey>> expression)
             where TModel : class
         {
-            ArgumentNullException.ThrowIfNull(lambdyBuilder);
-            ArgumentNullException.ThrowIfNull(expression);
+            if (lambdyBuilder is null) throw new ArgumentNullException(nameof(lambdyBuilder));
+            if (expression is null) throw new ArgumentNullException(nameof(expression));
             
             lambdyBuilder
                 .ExpressionBuilder
@@ -52,8 +52,8 @@ namespace Lambdy
             Expression<Func<TModel, TKey>> expression)
             where TModel : class
         {
-            ArgumentNullException.ThrowIfNull(lambdyBuilder);
-            ArgumentNullException.ThrowIfNull(expression);
+            if (lambdyBuilder is null) throw new ArgumentNullException(nameof(lambdyBuilder));
+            if (expression is null) throw new ArgumentNullException(nameof(expression));
             
             lambdyBuilder
                 .ExpressionBuilder
@@ -66,8 +66,8 @@ namespace Lambdy
             Expression<Func<TModel, TKey>> expression)
             where TModel : class
         {
-            ArgumentNullException.ThrowIfNull(lambdyBuilder);
-            ArgumentNullException.ThrowIfNull(expression);
+            if (lambdyBuilder is null) throw new ArgumentNullException(nameof(lambdyBuilder));
+            if (expression is null) throw new ArgumentNullException(nameof(expression));
             
             lambdyBuilder
                 .ExpressionBuilder
@@ -80,8 +80,8 @@ namespace Lambdy
             Expression<Func<TModel, TKey>> expression)
             where TModel : class
         {
-            ArgumentNullException.ThrowIfNull(lambdyBuilder);
-            ArgumentNullException.ThrowIfNull(expression);
+            if (lambdyBuilder is null) throw new ArgumentNullException(nameof(lambdyBuilder));
+            if (expression is null) throw new ArgumentNullException(nameof(expression));
             
             lambdyBuilder
                 .ExpressionBuilder

--- a/Lambdy/LambdyBuilderExtensions.cs
+++ b/Lambdy/LambdyBuilderExtensions.cs
@@ -8,8 +8,11 @@ namespace Lambdy
         public static ILambdyBuilder<TModel> Select<TModel, TSelectModel>(
             this ILambdyBuilder<TModel> lambdyBuilder,
             Expression<Func<TModel, TSelectModel>> expression)
-            where TModel: class
+            where TModel : class
         {
+            ArgumentNullException.ThrowIfNull(lambdyBuilder);
+            ArgumentNullException.ThrowIfNull(expression);
+            
             lambdyBuilder
                 .ExpressionBuilder
                 .AddSelectExpression(expression.Body);
@@ -19,8 +22,11 @@ namespace Lambdy
         public static ILambdyBuilder<TModel> Where<TModel>(
             this ILambdyBuilder<TModel> lambdyBuilder,
             Expression<Func<TModel, bool>> expression) 
-            where TModel: class
+            where TModel : class
         {
+            ArgumentNullException.ThrowIfNull(lambdyBuilder);
+            ArgumentNullException.ThrowIfNull(expression);
+            
             lambdyBuilder
                 .ExpressionBuilder
                 .AddWhereExpression(expression.Body);
@@ -32,6 +38,9 @@ namespace Lambdy
             Expression<Func<TModel, TKey>> expression)
             where TModel : class
         {
+            ArgumentNullException.ThrowIfNull(lambdyBuilder);
+            ArgumentNullException.ThrowIfNull(expression);
+            
             lambdyBuilder
                 .ExpressionBuilder
                 .AddOrderByExpression(expression.Body);
@@ -43,6 +52,9 @@ namespace Lambdy
             Expression<Func<TModel, TKey>> expression)
             where TModel : class
         {
+            ArgumentNullException.ThrowIfNull(lambdyBuilder);
+            ArgumentNullException.ThrowIfNull(expression);
+            
             lambdyBuilder
                 .ExpressionBuilder
                 .AddThenByExpression(expression.Body);
@@ -54,6 +66,9 @@ namespace Lambdy
             Expression<Func<TModel, TKey>> expression)
             where TModel : class
         {
+            ArgumentNullException.ThrowIfNull(lambdyBuilder);
+            ArgumentNullException.ThrowIfNull(expression);
+            
             lambdyBuilder
                 .ExpressionBuilder
                 .AddOrderByDescExpression(expression.Body);
@@ -65,6 +80,9 @@ namespace Lambdy
             Expression<Func<TModel, TKey>> expression)
             where TModel : class
         {
+            ArgumentNullException.ThrowIfNull(lambdyBuilder);
+            ArgumentNullException.ThrowIfNull(expression);
+            
             lambdyBuilder
                 .ExpressionBuilder
                 .AddThenByDescExpression(expression.Body);

--- a/Lambdy/LambdyBuilderExtensions.cs
+++ b/Lambdy/LambdyBuilderExtensions.cs
@@ -10,8 +10,8 @@ namespace Lambdy
             Expression<Func<TModel, TSelectModel>> expression)
             where TModel : class
         {
-            if (lambdyBuilder is null) throw new ArgumentNullException(nameof(lambdyBuilder));
-            if (expression is null) throw new ArgumentNullException(nameof(expression));
+            lambdyBuilder.ThrowIfNull(nameof(lambdyBuilder));
+            expression.ThrowIfNull(nameof(expression));
             
             lambdyBuilder
                 .ExpressionBuilder
@@ -24,8 +24,8 @@ namespace Lambdy
             Expression<Func<TModel, bool>> expression) 
             where TModel : class
         {
-            if (lambdyBuilder is null) throw new ArgumentNullException(nameof(lambdyBuilder));
-            if (expression is null) throw new ArgumentNullException(nameof(expression));
+            lambdyBuilder.ThrowIfNull(nameof(lambdyBuilder));
+            expression.ThrowIfNull(nameof(expression));
             
             lambdyBuilder
                 .ExpressionBuilder
@@ -38,8 +38,8 @@ namespace Lambdy
             Expression<Func<TModel, TKey>> expression)
             where TModel : class
         {
-            if (lambdyBuilder is null) throw new ArgumentNullException(nameof(lambdyBuilder));
-            if (expression is null) throw new ArgumentNullException(nameof(expression));
+            lambdyBuilder.ThrowIfNull(nameof(lambdyBuilder));
+            expression.ThrowIfNull(nameof(expression));
             
             lambdyBuilder
                 .ExpressionBuilder
@@ -52,8 +52,8 @@ namespace Lambdy
             Expression<Func<TModel, TKey>> expression)
             where TModel : class
         {
-            if (lambdyBuilder is null) throw new ArgumentNullException(nameof(lambdyBuilder));
-            if (expression is null) throw new ArgumentNullException(nameof(expression));
+            lambdyBuilder.ThrowIfNull(nameof(lambdyBuilder));
+            expression.ThrowIfNull(nameof(expression));
             
             lambdyBuilder
                 .ExpressionBuilder
@@ -66,8 +66,8 @@ namespace Lambdy
             Expression<Func<TModel, TKey>> expression)
             where TModel : class
         {
-            if (lambdyBuilder is null) throw new ArgumentNullException(nameof(lambdyBuilder));
-            if (expression is null) throw new ArgumentNullException(nameof(expression));
+            lambdyBuilder.ThrowIfNull(nameof(lambdyBuilder));
+            expression.ThrowIfNull(nameof(expression));
             
             lambdyBuilder
                 .ExpressionBuilder
@@ -80,8 +80,8 @@ namespace Lambdy
             Expression<Func<TModel, TKey>> expression)
             where TModel : class
         {
-            if (lambdyBuilder is null) throw new ArgumentNullException(nameof(lambdyBuilder));
-            if (expression is null) throw new ArgumentNullException(nameof(expression));
+            lambdyBuilder.ThrowIfNull(nameof(lambdyBuilder));
+            expression.ThrowIfNull(nameof(expression));
             
             lambdyBuilder
                 .ExpressionBuilder

--- a/Lambdy/LambdyCompilerOptions.cs
+++ b/Lambdy/LambdyCompilerOptions.cs
@@ -2,6 +2,6 @@
 {
     public class LambdyCompilerOptions
     {
-        public bool RemoveEmptyTokens { get; set; }
+        public bool RemoveEmptyTokens { get; set; } = true;
     }
 }

--- a/Lambdy/LambdyQuery.cs
+++ b/Lambdy/LambdyQuery.cs
@@ -1,4 +1,5 @@
-﻿using Lambdy.Builders;
+﻿using System;
+using Lambdy.Builders;
 using Lambdy.Compilers.Query;
 using Lambdy.Compilers.Query.Abstract;
 

--- a/Lambdy/LambdyQuery.cs
+++ b/Lambdy/LambdyQuery.cs
@@ -11,7 +11,7 @@ namespace Lambdy
         
         public static ILambdyBuilder<TModel> ByModel<TModel>(TModel model) where TModel : class
         {
-            if (model is null) throw new ArgumentNullException(nameof(model));
+            model.ThrowIfNull(nameof(model));
             return ByModel<TModel>();
         }
         

--- a/Lambdy/LambdyQuery.cs
+++ b/Lambdy/LambdyQuery.cs
@@ -8,12 +8,13 @@ namespace Lambdy
     {
         private static readonly QueryCompiler QueryCompiler = new RecursiveQueryCompiler();
         
-        public static ILambdyBuilder<TModel> ByModel<TModel>(TModel model) where TModel: class
+        public static ILambdyBuilder<TModel> ByModel<TModel>(TModel model) where TModel : class
         {
+            ArgumentNullException.ThrowIfNull(model);
             return ByModel<TModel>();
         }
         
-        public static ILambdyBuilder<TModel> ByModel<TModel>() where TModel: class
+        public static ILambdyBuilder<TModel> ByModel<TModel>() where TModel : class
         {
             return new LambdyBuilder<TModel>(QueryCompiler);
         }

--- a/Lambdy/LambdyQuery.cs
+++ b/Lambdy/LambdyQuery.cs
@@ -10,7 +10,7 @@ namespace Lambdy
         
         public static ILambdyBuilder<TModel> ByModel<TModel>(TModel model) where TModel : class
         {
-            ArgumentNullException.ThrowIfNull(model);
+            if (model is null) throw new ArgumentNullException(nameof(model));
             return ByModel<TModel>();
         }
         

--- a/Lambdy/LambdyResult.cs
+++ b/Lambdy/LambdyResult.cs
@@ -4,8 +4,8 @@ namespace Lambdy
 {
     public class LambdyResult
     {
-        public string Sql { get; set; }
+        public string Sql { get; set; } = string.Empty;
         
-        public Dictionary<string, object> Parameters { get; set; }
+        public Dictionary<string, object> Parameters { get; set; } = new Dictionary<string, object>();
     }
 }

--- a/Lambdy/Parameters/ParameterTracker.cs
+++ b/Lambdy/Parameters/ParameterTracker.cs
@@ -15,8 +15,8 @@ namespace Lambdy.Parameters
             string key,
             object value)
         {
-            ArgumentNullException.ThrowIfNull(key);
-            ArgumentNullException.ThrowIfNull(value);
+            if (key is null) throw new ArgumentNullException(nameof(key));
+            if (value is null) throw new ArgumentNullException(nameof(value));
 
             if (key.IndexOf(_paramPrefix, StringComparison.Ordinal) < 0)
             {
@@ -28,7 +28,7 @@ namespace Lambdy.Parameters
         
         public string AddParameter(object value)
         {
-            ArgumentNullException.ThrowIfNull(value);
+            if (value is null) throw new ArgumentNullException(nameof(value));
             
             var param = GetNextParameterName();
             Parameters.Add(param, value);

--- a/Lambdy/Parameters/ParameterTracker.cs
+++ b/Lambdy/Parameters/ParameterTracker.cs
@@ -15,8 +15,8 @@ namespace Lambdy.Parameters
             string key,
             object value)
         {
-            if (key is null) throw new ArgumentNullException(nameof(key));
-            if (value is null) throw new ArgumentNullException(nameof(value));
+            key.ThrowIfNull(nameof(key));
+            value.ThrowIfNull(nameof(value));
 
             if (key.IndexOf(_paramPrefix, StringComparison.Ordinal) < 0)
             {
@@ -28,7 +28,7 @@ namespace Lambdy.Parameters
         
         public string AddParameter(object value)
         {
-            if (value is null) throw new ArgumentNullException(nameof(value));
+            value.ThrowIfNull(nameof(value));
             
             var param = GetNextParameterName();
             Parameters.Add(param, value);

--- a/Lambdy/Parameters/ParameterTracker.cs
+++ b/Lambdy/Parameters/ParameterTracker.cs
@@ -9,12 +9,15 @@ namespace Lambdy.Parameters
 
         private int _paramIndex;
 
-        private static string _paramPrefix = "@";
+        private const string _paramPrefix = "@";
 
         public void AddParameter(
             string key,
             object value)
         {
+            ArgumentNullException.ThrowIfNull(key);
+            ArgumentNullException.ThrowIfNull(value);
+
             if (key.IndexOf(_paramPrefix, StringComparison.Ordinal) < 0)
             {
                 key = $"{_paramPrefix}{key}";
@@ -25,6 +28,8 @@ namespace Lambdy.Parameters
         
         public string AddParameter(object value)
         {
+            ArgumentNullException.ThrowIfNull(value);
+            
             var param = GetNextParameterName();
             Parameters.Add(param, value);
             return param;

--- a/Lambdy/Visitors/ExpressionNodeSql/RecursiveNodeSqlVisitor.cs
+++ b/Lambdy/Visitors/ExpressionNodeSql/RecursiveNodeSqlVisitor.cs
@@ -18,7 +18,7 @@ namespace Lambdy.Visitors.ExpressionNodeSql
             _stringBuilder = stringBuilder;
         }
         
-        public ParameterTracker ParameterTracker { get; private set; }
+        public ParameterTracker? ParameterTracker { get; private set; }
 
         public void SetParameterTracker(ParameterTracker parameterTracker)
         {


### PR DESCRIPTION
## Summary
- Upgrade to .NET Standard 2.1
- Add nullability annotations to all public APIs
- Add ArgumentNullException.ThrowIfNull() validation

## Changes
- Upgraded Lambdy.csproj from netstandard2.0 to netstandard2.1
- Enabled nullable reference types
- Updated Nerdbank.GitVersioning
- Added nullability annotations
- Added parameter validation

No breaking changes.